### PR TITLE
HOUR-1614 Keeping up with the chrome, need to use 'new-password' inst…

### DIFF
--- a/packages/react-select/src/Select.js
+++ b/packages/react-select/src/Select.js
@@ -1428,7 +1428,7 @@ export default class Select extends Component<Props, State> {
     return (
       <Input
         autoCapitalize="none"
-        autoComplete="off"
+        autoComplete="new-password"
         autoCorrect="off"
         cx={cx}
         getStyles={this.getStyles}


### PR DESCRIPTION
using 'new-password' to disable chrome's address autofill.

Doesn't always work for autocomplete with text fields, but for select's this seems to do it.